### PR TITLE
Add running migrations on release phase.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+release: npm run migration:run
 web: node dist/index.js


### PR DESCRIPTION
We need to run migrations on release instead of running it manually.