### PR TITLE
Fix attendance time issue, again

### DIFF
--- a/src/controllers/EventController.ts
+++ b/src/controllers/EventController.ts
@@ -129,7 +129,11 @@ export class EventController {
       multipleAttendanceQuery
     );
 
-    return { attendances };
+    const mappedAttendances = attendances.map(attendance =>
+      this.attendanceMapper.entityToResponse(attendance)
+    );
+
+    return { attendances: mappedAttendances };
   }
 
   @Post('/:eventID/attendance')
@@ -142,8 +146,13 @@ export class EventController {
     @CurrentUser() officer: AppUser
   ): Promise<AttendanceResponse | undefined> {
     const { attendeeId } = attendanceCheckOffRequest;
+    const checkedOffAttendance = await this.attendanceService.checkOffAttendance(
+      eventID,
+      attendeeId,
+      officer.id
+    );
 
-    return this.attendanceService.checkOffAttendance(eventID, attendeeId, officer.id);
+    return this.attendanceMapper.entityToResponse(checkedOffAttendance);
   }
 
   @Post('/:eventID/signin')

--- a/src/entities/Attendance.ts
+++ b/src/entities/Attendance.ts
@@ -20,10 +20,10 @@ export class Attendance {
   event: Event;
 
   @Column('timestamp')
-  startTime: string;
+  startTime: Date;
 
   @Column('timestamp', { nullable: true })
-  endTime?: string;
+  endTime?: Date;
 
   @Column({ nullable: true })
   points?: number;

--- a/src/services/AttendanceService.ts
+++ b/src/services/AttendanceService.ts
@@ -3,7 +3,7 @@ import { MultipleAttendanceQuery } from '@Payloads';
 import { AppUserService, AppUserServiceImpl } from './AppUserService';
 
 import { getRepository, FindManyOptions } from 'typeorm';
-import { differenceInMinutes, formatISO, parseISO } from 'date-fns';
+import { differenceInMinutes } from 'date-fns';
 
 export class AttendanceService {
   constructor(private appUserService: AppUserService) {}
@@ -82,7 +82,7 @@ export class AttendanceService {
       return undefined;
     }
 
-    attendance.endTime = formatISO(new Date());
+    attendance.endTime = new Date();
     attendance.officer = await this.appUserService.getAppUserById(officerId);
     attendance.points = this.getAttendancePoints(attendance);
 
@@ -90,10 +90,7 @@ export class AttendanceService {
   }
 
   getAttendancePoints(attendance: Attendance): number {
-    const diffMinutes: number = differenceInMinutes(
-      parseISO(attendance.endTime),
-      parseISO(attendance.startTime)
-    );
+    const diffMinutes: number = differenceInMinutes(attendance.endTime, attendance.startTime);
     const numHalfHours: number = diffMinutes / 30;
     const points: number = Math.round(numHalfHours / 2);
     if (points > 2) {
@@ -121,7 +118,7 @@ export class AttendanceService {
     const { role } = attendee;
     const attendance = { event, attendee, isInductee: role === AppUserRole.INDUCTEE };
     const newAttendance = attendanceRepository.create(attendance);
-    newAttendance.startTime = formatISO(new Date());
+    newAttendance.startTime = new Date();
 
     try {
       await attendanceRepository.insert(newAttendance);


### PR DESCRIPTION
Since TypeORM blindsided us by storing start and end times for Attendance entities into our db as timestamps, but gives those start and end times as Date objects when we query for attendances for an event, had to change startTime and endTime to type Date in src/Entity/Attendance.ts and apply the Attendance mapper to Attendance responses. This works because when Attendance responses are sent to frontend as JSON, the startTime and endTime become timestamps : )