### PR TITLE
Add script for updating attendances.

### DIFF
--- a/src/scripts/README.md
+++ b/src/scripts/README.md
@@ -1,0 +1,13 @@
+To whoever is reading this - sorry :)
+
+I'm too lazy to write everything out, so tl;dr:
+
+1. Grab the check in csv (export gsheets as csv) and run the python script - it'll generate a json
+2. The `restore_points.ts` script does a bunch of stuff
+   - Restores points for people who were checked off but did not get points
+   - Fix up a couple events (13/33) that couldn't be checked off
+   - Adds in people from the event check in Google Sheets
+
+Run the script like this `npm run build; NODE_ENV=development node -r dotenv/config -r module-alias/register dist/scripts/restore_points.js`
+
+The script will run against whatever db is specified in your `.env` file.

--- a/src/scripts/parse_attendance.py
+++ b/src/scripts/parse_attendance.py
@@ -1,0 +1,17 @@
+import json
+
+with open('attendance.csv') as file:
+    lines = file.readlines()
+    cleanLines = [line.strip().split(',') for line in lines][1:]
+
+    # email, name, id, hours
+    idx = [1,-5,-4,-3]
+    cleanestLines = [[line[i] for i in idx] for line in cleanLines]
+
+    x = []
+    for l in cleanestLines:
+        l[3] = float(l[3])
+        x.append({"email": l[0], "name": l[1], "id": l[2], "hours": l[3]})
+
+    with open('attendance.json', 'w') as outfile:
+        json.dump({"attendances": x}, outfile)

--- a/src/scripts/restore_points.ts
+++ b/src/scripts/restore_points.ts
@@ -1,0 +1,70 @@
+import { loadORM } from '../loaders';
+import { Attendance, AppUser, Event } from '../entities';
+import { AttendanceServiceImpl } from '../services';
+import { getRepository } from 'typeorm';
+
+import fs from 'fs';
+
+loadORM().then(async () => {
+  const attendanceRepo = getRepository(Attendance);
+  const userRepo = getRepository(AppUser);
+  const eventRepo = getRepository(Event);
+  const attendances = await attendanceRepo.find({ relations: ['attendee', 'event'] });
+
+  // calculate attendance points
+  for (const attendance of attendances) {
+    if (!attendance.endTime && attendance.event.id != 13) {
+      continue;
+    }
+
+    // these two events need to be fixed up
+    if (attendance.event.id == 13 || (attendance.event.id == 33 && attendance.isInductee)) {
+      attendance.startTime = (attendance.event.startDate as unknown) as Date;
+      attendance.endTime = (attendance.event.endDate as unknown) as Date;
+    }
+
+    const points = AttendanceServiceImpl.getAttendancePoints(attendance);
+    attendance.points = points;
+    console.log(
+      `Processing ${attendance.attendee.firstName} for event ${attendance.event.id}: ${attendance.points} points`
+    );
+
+    await attendanceRepo.save(attendance);
+  }
+
+  // do stuff from g sheets
+  fs.readFile('./src/scripts/attendance.json', 'utf8', async (_, data) => {
+    const rawAttendances = JSON.parse(data).attendances;
+    for (const a of rawAttendances) {
+      const user = await userRepo.findOne({ where: { email: a.email } });
+      const officer = await userRepo.findOne({ where: { id: 16 } });
+      if (!user) {
+        console.log(`Skipping ${a.email}`);
+        continue;
+      }
+
+      if (!a.id) {
+        continue;
+      }
+
+      const event = await eventRepo.findOne({ where: { id: a.id } });
+      if (!event) {
+        console.log(a.id);
+        continue;
+      }
+
+      const attendance = new Attendance();
+      attendance.event = event;
+      attendance.officer = officer;
+      attendance.attendee = user;
+      attendance.points = a.hours;
+
+      // o look typescript is very interesting :)
+      attendance.startTime = (event.startDate as unknown) as Date;
+      attendance.endTime = (event.endDate as unknown) as Date;
+      attendance.isInductee = user.role === 'inductee';
+
+      attendanceRepo.save(attendance);
+    }
+  });
+});


### PR DESCRIPTION
To whoever is reading this - sorry :)

I'm too lazy to write everything out, so tl;dr:

1. Grab the check in csv (export gsheets as csv) and run the python script - it'll generate a json
2. The `restore_points.ts` script does a bunch of stuff
   - Restores points for people who were checked off but did not get points
   - Fix up a couple events (13/33) that couldn't be checked off
   - Adds in people from the event check in Google Sheets

Run the script like this `npm run build; NODE_ENV=development node -r dotenv/config -r module-alias/register dist/scripts/restore_points.js`

The script will run against whatever db is specified in your `.env` file.