### PR TITLE
Fix user interview availability payload issue, fix interview dates type to array of ISO strings, add endpoint to update user interview availabilities

### DIFF
--- a/src/controllers/InductionClassController.ts
+++ b/src/controllers/InductionClassController.ts
@@ -20,8 +20,15 @@ export class InductionClassController {
       quarter.toUpperCase()
     );
 
+    const interviewDateStrings = interviewDates.map(interviewDate => {
+      // Jank type assertion for it to work, will need to come back to this later - Thai 12/01/20
+      const interviewDateString = { startDate: (interviewDate as unknown) as string };
+      return interviewDateString;
+    });
+
     const interviewDatesResponse = new InterviewDatesResponse();
-    interviewDatesResponse.interview = interviewDates.toString();
+    interviewDatesResponse.interviewWeeks = interviewDateStrings;
+
     return interviewDatesResponse;
   }
 }

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -20,6 +20,7 @@ import {
 } from '@Services';
 import {
   AppUserPostRequest,
+  AppUserInterviewAvailabilitiesRequest,
   AppUserResponse,
   AppUserRolesResponse,
   AppUserProfileResponse,
@@ -192,6 +193,28 @@ export class UserController {
     const points = await this.appUserService.getMemberPoints(userID);
 
     return points;
+  }
+
+  @Post('/:userID/interview-availabilities')
+  @UseBefore(InducteeAuthMiddleware)
+  @ResponseSchema(AppUserResponse)
+  @OpenAPI({ security: [{ TokenAuth: [] }] })
+  async updateUserInterviewAvailabilities(
+    @Param('userID') userID: number,
+    @Body() appUserInterviewAvailabilities: AppUserInterviewAvailabilitiesRequest,
+    @CurrentUser({ required: true }) requestingAppUser: AppUser
+  ): Promise<AppUserResponse | undefined> {
+    if (this.appUserService.isInvalidNonOfficerAccess(requestingAppUser, userID)) {
+      throw new ForbiddenError();
+    }
+
+    const appUserAvailabilities = appUserInterviewAvailabilities.availabilities;
+    const updatedAppUser = await this.appUserService.updateInterviewAvailabilities(
+      requestingAppUser,
+      appUserAvailabilities
+    );
+
+    return this.appUserMapper.entityToResponse(updatedAppUser);
   }
 }
 

--- a/src/payloads/AppUser.ts
+++ b/src/payloads/AppUser.ts
@@ -2,6 +2,7 @@ import {
   IsEnum,
   IsInt,
   IsString,
+  IsDateString,
   IsEmail,
   IsInstance,
   IsOptional,
@@ -9,7 +10,7 @@ import {
   IsBoolean,
 } from 'class-validator';
 
-import { AppUserRole, Availabilities } from '@Entities';
+import { AppUserRole } from '@Entities';
 import { Type } from 'class-transformer';
 import { AttendanceResponse } from './Attendance';
 
@@ -84,6 +85,12 @@ export class AppUserSignupRequest {
   readonly password: string;
 }
 
+export class AppUserInterviewAvailabilitiesRequest {
+  @ValidateNested({ each: true })
+  @Type(() => AppUserInterviewAvailability)
+  availabilities: AppUserInterviewAvailability[];
+}
+
 export class AppUserResponse {
   @IsInt()
   id: number;
@@ -110,8 +117,10 @@ export class AppUserResponse {
   @IsEnum(AppUserRole)
   role: string;
 
+  @ValidateNested({ each: true })
+  @Type(() => AppUserInterviewAvailability)
   @IsOptional()
-  availabilities?: Availabilities;
+  availabilities?: AppUserInterviewAvailability[];
 }
 
 export class AppUserEventResponse {
@@ -157,8 +166,10 @@ export class AppUserProfileResponse {
   @IsEnum(AppUserRole)
   role: string;
 
+  @ValidateNested({ each: true })
+  @Type(() => AppUserInterviewAvailability)
   @IsOptional()
-  availabilities: Availabilities;
+  availabilities?: AppUserInterviewAvailability[];
 }
 
 export class AppUserRolesResponse {
@@ -223,4 +234,12 @@ export class AppUserMemberPointsResponse {
 
   @IsInt()
   points: number;
+}
+
+export class AppUserInterviewAvailability {
+  @IsDateString()
+  start: string;
+
+  @IsDateString()
+  end: string;
 }

--- a/src/payloads/InterviewDates.ts
+++ b/src/payloads/InterviewDates.ts
@@ -1,3 +1,13 @@
+import { IsDateString, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+
 export class InterviewDatesResponse {
-  interview: string;
+  @ValidateNested({ each: true })
+  @Type(() => InterviewWeekStartDate)
+  interviewWeeks: InterviewWeekStartDate[];
+}
+
+export class InterviewWeekStartDate {
+  @IsDateString()
+  startDate: string;
 }

--- a/src/payloads/index.ts
+++ b/src/payloads/index.ts
@@ -10,6 +10,7 @@ export {
   AppUserPostRequest,
   AppUserEventRequest,
   AppUserSignupRequest,
+  AppUserInterviewAvailabilitiesRequest,
   AppUserResponse,
   AppUserEventResponse,
   AppUserRolesResponse,

--- a/src/services/AppUserService.ts
+++ b/src/services/AppUserService.ts
@@ -1,4 +1,10 @@
-import { AppUser, AppUserRole, InducteePointsView, MemberPointsView } from '@Entities';
+import {
+  AppUser,
+  AppUserRole,
+  InducteePointsView,
+  MemberPointsView,
+  Availabilities,
+} from '@Entities';
 import { MultipleUserQuery } from '@Payloads';
 import { Any, getRepository, FindManyOptions } from 'typeorm';
 
@@ -168,6 +174,14 @@ export class AppUserService {
   async getMemberPoints(appUserID: number): Promise<MemberPointsView | undefined> {
     const memberPointsRepo = getRepository(MemberPointsView);
     return await memberPointsRepo.findOne({ user: appUserID });
+  }
+
+  async updateInterviewAvailabilities(
+    appUser: AppUser,
+    availabilities: Availabilities
+  ): Promise<AppUser | undefined> {
+    appUser.availabilities = availabilities;
+    return this.saveAppUser(appUser);
   }
 }
 

--- a/src/services/InductionClassService.ts
+++ b/src/services/InductionClassService.ts
@@ -1,9 +1,5 @@
-import { Event, AppUser, Attendance, RSVP, InductionClass } from '@Entities';
-import { AttendanceService, AttendanceServiceImpl } from './AttendanceService';
-import { RSVPService, RSVPServiceImpl } from './RSVPService';
-
+import { InductionClass } from '@Entities';
 import { getRepository } from 'typeorm';
-import { MultipleAttendanceQuery } from '@Payloads';
 
 export class InductionClassService {
   /**
@@ -14,7 +10,6 @@ export class InductionClassService {
    */
   async getInterviewDatesByQuarter(quarter: string): Promise<Date[] | undefined> {
     const inductionClassRepository = getRepository(InductionClass);
-
     const inductionclass = await inductionClassRepository.findOne({ quarter });
 
     return inductionclass.interviewDates;


### PR DESCRIPTION
- Added the fix for interview availability payload issue, which had type "any" before on the api docs, due to the type of the availability field being an actual TS type and not a payload itself.

- Changed the interview dates type to being an array of ISO strings, just so I receive an array on the frontend and not a string that I have to split() (also, for some reason, the interview dates are in an array of strings instead of an array of Date objects, gonna leave that for some other time and/or someone else tho).

- Added post endpoint for interview availabilities to update user interview availabilities. Also decided to take in an array of ISO strings for the request body, since we do actually store them as an array of ISO strings in AppUser entity.

- Tested everything I changed for a bit and things seemed to work. Api docs are not broken as well with these changes.