### PR TITLE
Fix loading of induction class in mapper.

### DIFF
--- a/src/mappers/AppUserMapper.ts
+++ b/src/mappers/AppUserMapper.ts
@@ -61,7 +61,16 @@ export class AppUserMapper {
     appUserObj.id = appUserId;
 
     const appUserRepository = getRepository(AppUser);
+    const inductionClassRepository = getRepository(InductionClass);
     const appUser: AppUser = await appUserRepository.preload(appUserObj);
+
+    if (appUserRequest instanceof AppUserPostRequest) {
+      const inductionClass = await inductionClassRepository.findOne({
+        quarter: appUserRequest.inductionClassQuarter,
+      });
+
+      appUser.inductionClass = inductionClass;
+    }
 
     return appUser;
   }


### PR DESCRIPTION
Induction class was not loaded because of FK constraints in mapper with reliance on TypeORM preload, and needed to manually load induction class entity.