### PR TITLE
reformated calendar

### DIFF
--- a/frontend/src/pages/CalendarPage/index.js
+++ b/frontend/src/pages/CalendarPage/index.js
@@ -182,7 +182,7 @@ class CalendarPage extends React.Component {
           </Grid>
         </Grid>
 
-        <Grid item>
+        <Grid item className={classes.calendar}>
           <Grid container>
             <Grid item xs>
               <Paper>

--- a/frontend/src/pages/CalendarPage/styles.js
+++ b/frontend/src/pages/CalendarPage/styles.js
@@ -5,6 +5,9 @@ const styles = () => ({
   buttons: {
     marginBottom: '10px',
   },
+  calendar: {
+    width: '100%',
+  },
 });
 
 export default styles;


### PR DESCRIPTION
Added a class in styles for the calendar component, which limits width to 100%
Week view and month view will not overflow:
![overflow](https://user-images.githubusercontent.com/63177486/115647493-bcda7080-a2d8-11eb-85d8-871f42841ea1.png)
fix #189 