### PR TITLE
Added loading bars for event details page

### DIFF
--- a/frontend/src/pages/EventDetailsPage/components/AttendanceTable/index.tsx
+++ b/frontend/src/pages/EventDetailsPage/components/AttendanceTable/index.tsx
@@ -5,7 +5,7 @@ import AttendanceDeleteButton from '../buttons/AttendanceDeleteButton';
 import AttendanceEditButton from '../buttons/AttendanceEditButton';
 
 import { useInterval } from '@Hooks';
-import { Table } from '@SharedComponents';
+import { Loading, Table } from '@SharedComponents';
 import {
   AttendanceResponse,
   MultipleAttendanceResponse,
@@ -67,11 +67,13 @@ const attendanceResponseToAttendanceRow = (attendance: AttendanceResponse) => {
 function AttendanceTable(props: AttendanceTableProps) {
   const { getAttendances, eventId } = props;
   const [attendances, setAttendances] = useState<AttendanceResponse[]>([]);
+  const [isLoading, setIsLoading] = useState<Boolean>(true);
 
   useEffect(() => {
     const getEventAttendances = async () => {
       const { attendances: incomingAttendances } = await getAttendances();
       setAttendances(incomingAttendances);
+      setIsLoading(false);
     };
 
     getEventAttendances();
@@ -81,6 +83,7 @@ function AttendanceTable(props: AttendanceTableProps) {
     callback: async () => {
       const { attendances: incomingAttendances } = await getAttendances();
       setAttendances(incomingAttendances);
+      setIsLoading(false);
     },
     delay: 1000,
   });
@@ -119,6 +122,10 @@ function AttendanceTable(props: AttendanceTableProps) {
   const attendanceData = attendances.map(attendance =>
     attendanceResponseToAttendanceRow(attendance)
   );
+
+  if (isLoading) {
+    return <Loading />;
+  }
 
   return (
     <Table

--- a/frontend/src/pages/EventDetailsPage/components/CheckOffTable/index.tsx
+++ b/frontend/src/pages/EventDetailsPage/components/CheckOffTable/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { parseISO, format } from 'date-fns';
 
 import AttendanceDeleteButton from '../buttons/AttendanceDeleteButton';
-
+import { Loading } from '@SharedComponents';
 import { useInterval } from '@Hooks';
 import { Button, Table } from '@SharedComponents';
 import {
@@ -22,6 +22,7 @@ interface CheckOffTableProps {
 function CheckOffTable(props: CheckOffTableProps) {
   const { getAttendances, checkOffAttendance, eventId } = props;
   const [attendances, setAttendances] = useState<AttendanceResponse[]>([]);
+  const [isLoading, setIsLoading] = useState<Boolean>(true);
 
   const columns = [
     { title: 'Full Name', field: 'name' },
@@ -51,6 +52,7 @@ function CheckOffTable(props: CheckOffTableProps) {
     const getEventAttendances = async () => {
       const { attendances: incomingAttendances } = await getAttendances();
       setAttendances(incomingAttendances);
+      setIsLoading(false);
     };
 
     getEventAttendances();
@@ -60,6 +62,7 @@ function CheckOffTable(props: CheckOffTableProps) {
     callback: async () => {
       const { attendances: incomingAttendances } = await getAttendances();
       setAttendances(incomingAttendances);
+      setIsLoading(false);
     },
     delay: 1000,
   });
@@ -85,6 +88,10 @@ function CheckOffTable(props: CheckOffTableProps) {
 
     return attendanceToDisplay;
   });
+
+  if (isLoading) {
+    return <Loading />;
+  }
 
   return (
     <Table

--- a/frontend/src/pages/EventDetailsPage/components/EventDetails/index.tsx
+++ b/frontend/src/pages/EventDetailsPage/components/EventDetails/index.tsx
@@ -6,7 +6,7 @@ import DeleteEditButtons from '../DeleteEditButtons';
 import Links from '../Links/Links';
 import SignInButton from '../buttons/SignInButton';
 import RSVPButton from '../buttons/RSVPButton';
-
+import { Loading } from '@SharedComponents';
 import useStyles from './styles';
 
 import * as ROUTES from '@Constants/routes';
@@ -20,21 +20,24 @@ import { EventStatusEnum } from '@Services/EventService';
 
 import { getAffiliateEventAttendance } from '@Services/EventService';
 
-
 interface EventDetailsComponentProps {
   eventInfo: EventInfo;
   eventId: number;
 }
-
 function EventDetailsComponent(props: EventDetailsComponentProps) {
   const { eventInfo, eventId } = props;
   const classes = useStyles();
-  const [isSignedIn, setIsSignedIn] = useState<boolean>(true);
+  const [isSignedIn, setIsSignedIn] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
 
   useEffect(() => {
+    setIsLoading(true);
     const getAttendance = async () => {
       const affiliateAttendance = await getAffiliateEventAttendance(eventId);
       setIsSignedIn(affiliateAttendance.isSignedIn);
+      // As of 11/22/2022, affiliatAttendance does not return a value due to API issue.
+      // This is going to get fixed eventually
+      setIsLoading(false);
     };
     getAttendance();
   }, [eventId]);
@@ -85,6 +88,11 @@ function EventDetailsComponent(props: EventDetailsComponentProps) {
       </Typography>
     </Typography>
   );
+
+  if (isLoading) {
+    console.log('Reached loading here');
+    return <Loading />;
+  }
 
   return (
     <Grid container justify='center' spacing={3}>
@@ -150,9 +158,7 @@ function EventDetailsComponent(props: EventDetailsComponentProps) {
                         </Typography>
                       </Typography>
                     </Grid>
-                    <Grid item>
-                      {OfficerRenderPermission(StatusField)({})}
-                    </Grid>
+                    <Grid item>{OfficerRenderPermission(StatusField)({})}</Grid>
                   </Grid>
                 </Grid>
 
@@ -167,7 +173,10 @@ function EventDetailsComponent(props: EventDetailsComponentProps) {
                     <Grid item>
                       {InducteeRenderPermission(Links)({
                         urls,
-                        signIn: { url: signInURL, label: 'Sign In Form (Guest)' },
+                        signIn: {
+                          url: signInURL,
+                          label: 'Sign In Form (Guest)',
+                        },
                         rsvp: { url: rsvpURL, label: 'RSVP Form (Guest)' },
                         qrCode: {
                           url: ROUTES.EVENT_QRCODE_WITH_ID(eventId),

--- a/frontend/src/pages/EventDetailsPage/components/RSVPTable/index.tsx
+++ b/frontend/src/pages/EventDetailsPage/components/RSVPTable/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
 import { useInterval } from '@Hooks';
-import { Table } from '@SharedComponents';
+import { Loading, Table } from '@SharedComponents';
 import {
   RSVPResponse,
   MultipleRSVPResponse,
@@ -15,6 +15,7 @@ interface RSVPTableProps {
 function RSVPTable(props: RSVPTableProps) {
   const { getRSVPs } = props;
   const [rsvps, setRSVPs] = useState<RSVPResponse[]>([]);
+  const [isLoading, setIsLoading] = useState<Boolean>(true);
 
   const columns = [
     { title: 'Full Name', field: 'name' },
@@ -25,6 +26,7 @@ function RSVPTable(props: RSVPTableProps) {
     const getEventRSVPs = async () => {
       const { rsvps: incomingRSVPs } = await getRSVPs();
       setRSVPs(incomingRSVPs);
+      setIsLoading(false);
     };
 
     getEventRSVPs();
@@ -34,6 +36,7 @@ function RSVPTable(props: RSVPTableProps) {
     callback: async () => {
       const { rsvps: incomingRSVPs } = await getRSVPs();
       setRSVPs(incomingRSVPs);
+      setIsLoading(false);
     },
     delay: 1000,
   });
@@ -55,6 +58,10 @@ function RSVPTable(props: RSVPTableProps) {
 
     return rsvpToDisplay;
   });
+
+  if (isLoading) {
+    return <Loading />;
+  }
 
   return (
     <Table


### PR DESCRIPTION
These changes add loading bars for whenever every asset / data hasn't been loaded yet. Note that because we are having an issue with our dev API for attendance, this is not getting merged yet (because it will show events loading infinitely).